### PR TITLE
feat: Add pytest and pytest-asyncio for testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,8 @@ name: Test and Lint
 
 on:
   pull_request:
-    branches: [ main ]
+    branches:
+      - main
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,54 @@
+name: Test and Lint
+
+on:
+  pull_request:
+    branches: [ main ]
+  workflow_dispatch:
+
+jobs:
+  test-and-lint:
+    runs-on: ubuntu-latest
+    
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+      
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+      
+      - name: Install uv
+        run: |
+          curl -LsSf https://astral.sh/uv/install.sh | sh
+          echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+      
+      - name: Install dependencies with uv
+        run: |
+          uv pip install --all-extras
+      
+      - name: Run pytest
+        run: |
+          pytest
+      
+      - name: Run ruff format
+        run: |
+          ruff format .
+      
+      - name: Run ruff lint with fixes
+        run: |
+          ruff check --fix .
+      
+      - name: Check for changes
+        id: git-check
+        run: |
+          git diff --exit-code || echo "changes=true" >> $GITHUB_OUTPUT
+      
+      - name: Commit changes if any
+        if: steps.git-check.outputs.changes == 'true'
+        run: |
+          git config --local user.email "github-actions[bot]@users.noreply.github.com"
+          git config --local user.name "github-actions[bot]"
+          git add .
+          git commit -m "[Style]Apply ruff formatting and linting"
+          git push

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,8 @@ dependencies = [
 
 [dependency-groups]
 dev = [
+    "pytest>=8.3.5",
+    "pytest-asyncio>=0.26.0",
     "ruff>=0.11.6",
 ]
 

--- a/src/mcp_latest_document/scraper.py
+++ b/src/mcp_latest_document/scraper.py
@@ -1,0 +1,103 @@
+from dotenv import load_dotenv
+from urllib.parse import urlparse
+from bs4 import BeautifulSoup
+import httpx
+from markdownify import markdownify
+load_dotenv()
+
+class Scraper:
+    @staticmethod
+    async def get_html(url: str, timeout: int = 30) -> str:
+        """
+        Fetches HTML content from a specified URL using httpx.
+        
+        Args:
+            url (str): The URL to fetch HTML content from
+            timeout (int, optional): Request timeout in seconds. Defaults to 30.
+            
+        Returns:
+            str: The HTML content as a string
+            
+        Raises:
+            httpx.HTTPError: If the HTTP request fails
+        """
+        async with httpx.AsyncClient() as client:
+            response = await client.get(url, timeout=timeout)
+            response.raise_for_status()  # Raise an exception for 4XX/5XX responses
+            return response.text
+
+    @staticmethod
+    def get_html_sync(url: str, timeout: int = 30) -> str:
+        """
+        Synchronous version of get_html function.
+        Fetches HTML content from a specified URL using httpx.
+        
+        Args:
+            url (str): The URL to fetch HTML content from
+            timeout (int, optional): Request timeout in seconds. Defaults to 30.
+            
+        Returns:
+            str: The HTML content as a string
+            
+        Raises:
+            httpx.HTTPError: If the HTTP request fails
+        """
+        with httpx.Client() as client:
+            response = client.get(url, timeout=timeout)
+            response.raise_for_status()  # Raise an exception for 4XX/5XX responses
+            return response.text
+        
+    @staticmethod
+    def convert_to_markdown(html: str) -> str:
+        """
+        Converts HTML to Markdown using markdownify library.
+        
+        Args:
+            html (str): The HTML content to convert
+            
+        Returns:
+            str: The Markdown content as a string
+        """
+        return markdownify(html)
+
+    @staticmethod
+    def get_base_url(url: str) -> str:
+        """
+        Extracts the base URL from a given URL.
+        
+        Args:
+            url (str): The full URL
+            
+        Returns:
+            str: The base URL (scheme + netloc)
+        """
+        parsed_url = urlparse(url)
+        base_url = f"{parsed_url.scheme}://{parsed_url.netloc}"
+        return base_url
+    
+    @staticmethod
+    def findout_links(url: str) -> list[str]:
+        """
+        Finds all links in an HTML document.
+        
+        Args:
+            url (str): The URL to fetch HTML content from
+            
+        Returns:
+            list[str]: A list of links found in the HTML content
+        """
+        html = Scraper.get_html_sync(url)
+        soup = BeautifulSoup(html, 'lxml')
+        links = [link for link in soup.find_all("a")]
+        base_url = Scraper.get_base_url(url)
+        links_dict= {}
+        for link in links:
+            url = link.get("href")
+            if not url:
+                continue
+            if url.startswith("/"):
+                links_dict[link.text] = base_url + url
+            else:
+                links_dict[link.text] = url
+        return links_dict
+

--- a/src/mcp_latest_document/server.py
+++ b/src/mcp_latest_document/server.py
@@ -5,107 +5,10 @@ from urllib.parse import urlparse
 from bs4 import BeautifulSoup
 import httpx
 from markdownify import markdownify
-
+from .scraper import Scraper
 load_dotenv()
 
 URLS = os.environ.get("URLS", "https://react.dev/reference/react-dom").split(",")
-
-class Scraper:
-    @staticmethod
-    async def get_html(url: str, timeout: int = 30) -> str:
-        """
-        Fetches HTML content from a specified URL using httpx.
-        
-        Args:
-            url (str): The URL to fetch HTML content from
-            timeout (int, optional): Request timeout in seconds. Defaults to 30.
-            
-        Returns:
-            str: The HTML content as a string
-            
-        Raises:
-            httpx.HTTPError: If the HTTP request fails
-        """
-        async with httpx.AsyncClient() as client:
-            response = await client.get(url, timeout=timeout)
-            response.raise_for_status()  # Raise an exception for 4XX/5XX responses
-            return response.text
-
-    @staticmethod
-    def get_html_sync(url: str, timeout: int = 30) -> str:
-        """
-        Synchronous version of get_html function.
-        Fetches HTML content from a specified URL using httpx.
-        
-        Args:
-            url (str): The URL to fetch HTML content from
-            timeout (int, optional): Request timeout in seconds. Defaults to 30.
-            
-        Returns:
-            str: The HTML content as a string
-            
-        Raises:
-            httpx.HTTPError: If the HTTP request fails
-        """
-        with httpx.Client() as client:
-            response = client.get(url, timeout=timeout)
-            response.raise_for_status()  # Raise an exception for 4XX/5XX responses
-            return response.text
-        
-    @staticmethod
-    def convert_to_markdown(html: str) -> str:
-        """
-        Converts HTML to Markdown using markdownify library.
-        
-        Args:
-            html (str): The HTML content to convert
-            
-        Returns:
-            str: The Markdown content as a string
-        """
-        return markdownify(html)
-
-    @staticmethod
-    def get_base_url(url: str) -> str:
-        """
-        Extracts the base URL from a given URL.
-        
-        Args:
-            url (str): The full URL
-            
-        Returns:
-            str: The base URL (scheme + netloc)
-        """
-        parsed_url = urlparse(url)
-        base_url = f"{parsed_url.scheme}://{parsed_url.netloc}"
-        return base_url
-    
-    @staticmethod
-    def findout_links(url: str) -> list[str]:
-        """
-        Finds all links in an HTML document.
-        
-        Args:
-            url (str): The URL to fetch HTML content from
-            
-        Returns:
-            list[str]: A list of links found in the HTML content
-        """
-        html = Scraper.get_html_sync(url)
-        soup = BeautifulSoup(html, 'lxml')
-        links = [link for link in soup.find_all("a")]
-        base_url = Scraper.get_base_url(url)
-        links_dict= {}
-        for link in links:
-            url = link.get("href")
-            if not url:
-                continue
-            if url.startswith("/"):
-                links_dict[link.text] = base_url + url
-            else:
-                links_dict[link.text] = url
-        return links_dict
-
 
 # Create an MCP server
 mcp = FastMCP("Provide infroamtion based on specified Document")

--- a/tests/test_scraper.py
+++ b/tests/test_scraper.py
@@ -1,0 +1,123 @@
+import pytest
+import asyncio
+import httpx
+from unittest.mock import patch, MagicMock
+from bs4 import BeautifulSoup
+from src.mcp_latest_document.scraper import Scraper
+
+
+@pytest.fixture
+def sample_html():
+    return """
+    <!DOCTYPE html>
+    <html>
+    <head>
+        <title>Test Page</title>
+    </head>
+    <body>
+        <h1>Hello World</h1>
+        <p>This is a <strong>test</strong> paragraph.</p>
+        <a href="/relative-link">Relative Link</a>
+        <a href="https://example.com/absolute-link">Absolute Link</a>
+        <a>Link without href</a>
+    </body>
+    </html>
+    """
+
+
+@pytest.mark.asyncio
+async def test_get_html():
+    # Mock the httpx.AsyncClient to avoid actual HTTP requests
+    with patch('httpx.AsyncClient') as mock_client:
+        mock_response = MagicMock()
+        mock_response.text = "<html>Test content</html>"
+        mock_response.raise_for_status = MagicMock()
+        
+        mock_client.return_value.__aenter__.return_value.get.return_value = mock_response
+        
+        result = await Scraper.get_html("https://example.com")
+        
+        assert result == "<html>Test content</html>"
+        mock_client.return_value.__aenter__.return_value.get.assert_called_once_with(
+            "https://example.com", timeout=30
+        )
+
+
+def test_get_html_sync():
+    # Mock the httpx.Client to avoid actual HTTP requests
+    with patch('httpx.Client') as mock_client:
+        mock_response = MagicMock()
+        mock_response.text = "<html>Test content</html>"
+        mock_response.raise_for_status = MagicMock()
+        
+        mock_client.return_value.__enter__.return_value.get.return_value = mock_response
+        
+        result = Scraper.get_html_sync("https://example.com")
+        
+        assert result == "<html>Test content</html>"
+        mock_client.return_value.__enter__.return_value.get.assert_called_once_with(
+            "https://example.com", timeout=30
+        )
+
+
+def test_convert_to_markdown():
+    html = "<h1>Title</h1><p>This is <strong>bold</strong> text.</p>"
+    expected_markdown = "Title\n=====\n\nThis is **bold** text."
+    
+    result = Scraper.convert_to_markdown(html)
+    
+    assert result == expected_markdown
+
+
+def test_get_base_url():
+    test_cases = [
+        ("https://example.com/path/to/page", "https://example.com"),
+        ("http://test.org/index.html?param=value", "http://test.org"),
+        ("https://subdomain.example.com/path", "https://subdomain.example.com"),
+    ]
+    
+    for url, expected in test_cases:
+        result = Scraper.get_base_url(url)
+        assert result == expected
+
+
+def test_findout_links(sample_html):
+    # Mock the get_html_sync method to return our sample HTML
+    with patch('src.mcp_latest_document.scraper.Scraper.get_html_sync') as mock_get_html:
+        mock_get_html.return_value = sample_html
+        
+        # Mock BeautifulSoup to use our sample HTML
+        with patch('src.mcp_latest_document.scraper.BeautifulSoup') as mock_bs:
+            soup = BeautifulSoup(sample_html, 'lxml')
+            mock_bs.return_value = soup
+            
+            result = Scraper.findout_links("https://example.com")
+            
+            assert isinstance(result, dict)
+            assert "Relative Link" in result
+            assert result["Relative Link"] == "https://example.com/relative-link"
+            assert "Absolute Link" in result
+            assert result["Absolute Link"] == "https://example.com/absolute-link"
+            assert len(result) == 2  # Should not include the link without href
+
+
+def test_findout_links_error_handling():
+    # Test error handling when get_html_sync raises an exception
+    with patch('src.mcp_latest_document.scraper.Scraper.get_html_sync') as mock_get_html:
+        mock_get_html.side_effect = httpx.HTTPError("Error fetching URL")
+        
+        with pytest.raises(httpx.HTTPError):
+            Scraper.findout_links("https://example.com")
+
+
+@pytest.mark.asyncio
+async def test_get_html_error_handling():
+    # Test error handling when the HTTP request fails
+    with patch('httpx.AsyncClient') as mock_client:
+        mock_response = MagicMock()
+        mock_response.raise_for_status.side_effect = httpx.HTTPError("HTTP Error")
+        
+        mock_client.return_value.__aenter__.return_value.get.return_value = mock_response
+        
+        with pytest.raises(httpx.HTTPError):
+            await Scraper.get_html("https://example.com")

--- a/uv.lock
+++ b/uv.lock
@@ -330,6 +330,15 @@ wheels = [
 ]
 
 [[package]]
+name = "iniconfig"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f2/97/ebf4da567aa6827c909642694d71c9fcf53e5b504f2d96afea02718862f3/iniconfig-2.1.0.tar.gz", hash = "sha256:3abbd2e30b36733fee78f9c7f7308f2d0050e88f0087fd25c2645f63c773e1c7", size = 4793 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2c/e1/e6716421ea10d38022b952c159d5161ca1193197fb744506875fbb87ea7b/iniconfig-2.1.0-py3-none-any.whl", hash = "sha256:9deba5723312380e77435581c6bf4935c94cbfab9b1ed33ef8d238ea168eb760", size = 6050 },
+]
+
+[[package]]
 name = "jaraco-classes"
 version = "3.4.0"
 source = { registry = "https://pypi.org/simple" }
@@ -541,6 +550,8 @@ dependencies = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "pytest" },
+    { name = "pytest-asyncio" },
     { name = "ruff" },
 ]
 
@@ -557,7 +568,11 @@ requires-dist = [
 ]
 
 [package.metadata.requires-dev]
-dev = [{ name = "ruff", specifier = ">=0.11.6" }]
+dev = [
+    { name = "pytest", specifier = ">=8.3.5" },
+    { name = "pytest-asyncio", specifier = ">=0.26.0" },
+    { name = "ruff", specifier = ">=0.11.6" },
+]
 
 [[package]]
 name = "mdurl"
@@ -615,6 +630,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a1/d4/1fc4078c65507b51b96ca8f8c3ba19e6a61c8253c72794544580a7b6c24d/packaging-25.0.tar.gz", hash = "sha256:d443872c98d677bf60f6a1f2f8c1cb748e8fe762d2bf9d3148b5599295b0fc4f", size = 165727 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/20/12/38679034af332785aac8774540895e234f4d07f7545804097de4b666afd8/packaging-25.0-py3-none-any.whl", hash = "sha256:29572ef2b1f17581046b3a2227d5c611fb25ec70ca1ba8554b24b0e69331a484", size = 66469 },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.5.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/96/2d/02d4312c973c6050a18b314a5ad0b3210edb65a906f868e31c111dede4a6/pluggy-1.5.0.tar.gz", hash = "sha256:2cffa88e94fdc978c4c574f15f9e59b7f4201d439195c3715ca9e2486f1d0cf1", size = 67955 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/5f/e351af9a41f866ac3f1fac4ca0613908d9a41741cfcf2228f4ad853b697d/pluggy-1.5.0-py3-none-any.whl", hash = "sha256:44e1ad92c8ca002de6377e165f3e0f1be63266ab4d554740532335b9d75ea669", size = 20556 },
 ]
 
 [[package]]
@@ -758,6 +782,35 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/e7/82/28175b2414effca1cdac8dc99f76d660e7a4fb0ceefa4b4ab8f5f6742925/pyproject_hooks-1.2.0.tar.gz", hash = "sha256:1e859bd5c40fae9448642dd871adf459e5e2084186e8d2c2a79a824c970da1f8", size = 19228 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/bd/24/12818598c362d7f300f18e74db45963dbcb85150324092410c8b49405e42/pyproject_hooks-1.2.0-py3-none-any.whl", hash = "sha256:9e5c6bfa8dcc30091c74b0cf803c81fdd29d94f01992a7707bc97babb1141913", size = 10216 },
+]
+
+[[package]]
+name = "pytest"
+version = "8.3.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "tomli", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ae/3c/c9d525a414d506893f0cd8a8d0de7706446213181570cdbd766691164e40/pytest-8.3.5.tar.gz", hash = "sha256:f4efe70cc14e511565ac476b57c279e12a855b11f48f212af1080ef2263d3845", size = 1450891 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/30/3d/64ad57c803f1fa1e963a7946b6e0fea4a70df53c1a7fed304586539c2bac/pytest-8.3.5-py3-none-any.whl", hash = "sha256:c69214aa47deac29fad6c2a4f590b9c4a9fdb16a403176fe154b79c0b4d4d820", size = 343634 },
+]
+
+[[package]]
+name = "pytest-asyncio"
+version = "0.26.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8e/c4/453c52c659521066969523e87d85d54139bbd17b78f09532fb8eb8cdb58e/pytest_asyncio-0.26.0.tar.gz", hash = "sha256:c4df2a697648241ff39e7f0e4a73050b03f123f760673956cf0d72a4990e312f", size = 54156 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/20/7f/338843f449ace853647ace35870874f69a764d251872ed1b4de9f234822c/pytest_asyncio-0.26.0-py3-none-any.whl", hash = "sha256:7b51ed894f4fbea1340262bdae5135797ebbe21d8638978e35d31c6d19f72fb0", size = 19694 },
 ]
 
 [[package]]


### PR DESCRIPTION
This commit introduces pytest and pytest-asyncio as development dependencies for testing the application.

- Added `pytest>=8.3.5` and `pytest-asyncio>=0.26.0` to the `dev` dependency group in `pyproject.toml`.
- Updated `uv.lock` to include the new dependencies and their associated metadata.
- Moved the `Scraper` class to its own module (`src/mcp_latest_document/scraper.py`) and imported it in `src/mcp_latest_document/server.py` to improve code organization and testability.